### PR TITLE
Fixed report processing

### DIFF
--- a/helpers/parse-report.js
+++ b/helpers/parse-report.js
@@ -1,5 +1,6 @@
 module.exports = (rawReport) => {
-  const lines = rawReport.split('\n')
+  const report = rawReport.trim()
+  const lines = report.split('\n')
   const columns = lines[0].split('\t')
   return lines.slice(1).map(line => Object.fromEntries(line.split('\t').map((value, i) => [columns[i], value])))
 }

--- a/helpers/process-report.js
+++ b/helpers/process-report.js
@@ -1,23 +1,18 @@
 module.exports = (parsedReport, marketplace) => {
   const eanAsinMaps = getIdsMaps(parsedReport, 'ean')
   const asinSkuMaps = getIdsMaps(parsedReport, 'asin')
+  const connectedIdsMaps = eanAsinMaps.map(eanAsinMap => {
+    return {
+      ean: eanAsinMap.ean,
+      asinSkuMaps: asinSkuMaps.filter(asinSkuMap => eanAsinMap.asins.includes(asinSkuMap.asin))
+    }
+  })
   const connectedAsins = eanAsinMaps.flatMap(eanAsinMap => eanAsinMap.asins)
-  const connectedIdsMap = eanAsinMaps.map(eanAsinMap => {
-    return {
-      ean: eanAsinMap.ean,
-      asinSkuMaps: asinSkuMaps.filter(asinSkuMap => connectedAsins.includes(asinSkuMap.asin))
-    }
-  })
-  const orphanedIdsMap = eanAsinMaps.map(eanAsinMap => {
-    return {
-      ean: eanAsinMap.ean,
-      asinSkuMaps: asinSkuMaps.filter(asinSkuMap => !connectedAsins.includes(asinSkuMap.asin))
-    }
-  })
+  const orphanedasinSkuMaps = asinSkuMaps.filter(asinSkuMap => !connectedAsins.includes(asinSkuMap.asin))
   console.log(JSON.stringify(eanAsinMaps, null, 2))
   console.log(JSON.stringify(asinSkuMaps, null, 2))
-  console.log(JSON.stringify(connectedIdsMap, null, 2))
-  console.log(JSON.stringify(orphanedIdsMap, null, 2))
+  console.log(JSON.stringify(connectedIdsMaps, null, 2))
+  console.log(JSON.stringify(orphanedasinSkuMaps, null, 2))
 }
 
 function getIdsMaps (parsedReport, idType) {

--- a/helpers/process-report.js
+++ b/helpers/process-report.js
@@ -9,9 +9,6 @@ module.exports = (parsedReport, marketplace) => {
   })
   const connectedAsins = eanAsinMaps.flatMap(eanAsinMap => eanAsinMap.asins)
   const orphanedAsinsMaps = asinSkuMaps.filter(asinSkuMap => !connectedAsins.includes(asinSkuMap.asin))
-  console.log(JSON.stringify(eanAsinMaps, null, 2))
-  console.log(JSON.stringify(asinSkuMaps, null, 2))
-  console.log(JSON.stringify(productIdsMaps, null, 2))
   console.log(JSON.stringify(orphanedAsinsMaps, null, 2)) // to keep track of any orphaned products
   return {
     marketplace,

--- a/helpers/process-report.js
+++ b/helpers/process-report.js
@@ -7,57 +7,26 @@ module.exports = (parsedReport, marketplace) => {
 
 function getIdsMap (parsedReport, idType) {
   const listings = idType === 'ean' ? parsedReport.filter(listing => listing['product-id-type'] === '4') : parsedReport
-  const idKeysMaps = getIdKeysMaps(idType)
-  const idDuplets = listings.map(listing => Object.fromEntries(idKeysMaps.map(idKeysMap => [idKeysMap.key, listing[idKeysMap.listingKey]])))
-  const ids = [...new Set(listings.map(listing => listing[idKeysMaps[0].listingKey]))]
-  return ids.map(buildIdsMap(idDuplets, idKeysMaps))
+  const keyMaps = getKeyMaps(idType)
+  const idDuplets = listings.map(listing => Object.fromEntries(keyMaps.map(keyMap => [keyMap.key, listing[keyMap.listingKey]])))
+  const ids = [...new Set(listings.map(listing => listing[keyMaps[0].listingKey]))]
+  return ids.map(buildIdsMap(idDuplets, keyMaps))
 }
 
-function getIdKeysMaps (idType) {
-  const IdKeysMaps = [{ key: 'ean', listingKey: 'product-id' }, { key: 'asin', listingKey: 'asin1' }, { key: 'sellerSku', listingKey: 'seller-sku' }]
-  const idIndex = IdKeysMaps.findIndex(IdKeysMap => IdKeysMap.key === idType)
-  return IdKeysMaps.slice(idIndex, idIndex + 2)
+function getKeyMaps (idType) {
+  const keyMaps = [{ key: 'ean', listingKey: 'product-id' }, { key: 'asin', listingKey: 'asin1' }, { key: 'sellerSku', listingKey: 'seller-sku' }]
+  const idIndex = keyMaps.findIndex(keyMap => keyMap.key === idType)
+  return keyMaps.slice(idIndex, idIndex + 2)
 }
 
-function buildIdsMap (idDuplets, idKeysMaps) {
+function buildIdsMap (idDuplets, keyMaps) {
   return id => {
-    const matchingDuplets = idDuplets.filter(duplet => duplet[idKeysMaps[0].key] === id)
-    const idMapHandler = (idKeysMap, i) => i === 0 ? [idKeysMap.key, id] : [`${idKeysMap.key}s`, matchingDuplets.map(duplet => duplet[idKeysMaps[1].key])]
-    const idMap = idKeysMaps.map(idMapHandler)
+    const matchingDuplets = idDuplets.filter(duplet => duplet[keyMaps[0].key] === id)
+    const secondaryIds = [...new Set(matchingDuplets.map(duplet => duplet[keyMaps[1].key]))]
+    const idMap = [
+      [keyMaps[0].key, id],
+      [`${keyMaps[1].key}s`, secondaryIds]
+    ]
     return Object.fromEntries(idMap)
   }
 }
-
-// module.exports = (parsedReport, marketplace) => {
-//   const eans = [...new Set(parsedReport.map(listing => listing['product-id']))]
-//   return {
-//     marketplace,
-//     stockData: eans.map(getDataPerEan(parsedReport))
-//   }
-// }
-
-// function getDataPerEan(parsedReport) {
-//   return ean => {
-//     const matchingListings = parsedReport.filter(getMatchingListings(ean))
-//     return {
-//       ean,
-//       stocks: matchingListings.map(getStocksForEntry)
-//     }
-//   }
-// }
-
-// function getMatchingListings(ean) {
-//   return listing => listing['product-id'] === ean
-// }
-
-// function getStocksForEntry(listing) {
-//   return {
-//     asins: Object.entries(listing).filter(entry => entry[0].includes('asin')).map(entry => entry[1]).filter(asin => asin.length > 0),
-//     sellerSku: listing['seller-sku'],
-//     quantity: listing.quantity,
-//     pendingQuantity: listing['pending-quantity'],
-//     fulfilmentChannel: listing['fulfilment-channel'],
-//     status: listing.status,
-//     condition: listing['item-condition']
-//   }
-// }

--- a/helpers/process-report.js
+++ b/helpers/process-report.js
@@ -1,11 +1,26 @@
 module.exports = (parsedReport, marketplace) => {
-  const eanAsinMap = getIdsMap(parsedReport, 'ean')
-  const asinSkuMap = getIdsMap(parsedReport, 'asin')
+  const eanAsinMaps = getIdsMaps(parsedReport, 'ean')
+  const asinSkuMaps = getIdsMaps(parsedReport, 'asin')
+  const connectedAsins = eanAsinMaps.flatMap(eanAsinMap => eanAsinMap.asins)
+  const connectedIdsMap = eanAsinMaps.map(eanAsinMap => {
+    return {
+      ean: eanAsinMap.ean,
+      asinSkuMaps: asinSkuMaps.filter(asinSkuMap => connectedAsins.includes(asinSkuMap.asin))
+    }
+  })
+  const orphanedIdsMap = eanAsinMaps.map(eanAsinMap => {
+    return {
+      ean: eanAsinMap.ean,
+      asinSkuMaps: asinSkuMaps.filter(asinSkuMap => !connectedAsins.includes(asinSkuMap.asin))
+    }
+  })
   console.log(JSON.stringify(eanAsinMap, null, 2))
   console.log(JSON.stringify(asinSkuMap, null, 2))
+  console.log(JSON.stringify(connectedIdsMap, null, 2))
+  console.log(JSON.stringify(orphanedIdsMap, null, 2))
 }
 
-function getIdsMap (parsedReport, idType) {
+function getIdsMaps (parsedReport, idType) {
   const listings = idType === 'ean' ? parsedReport.filter(listing => listing['product-id-type'] === '4') : parsedReport
   const keyMaps = getKeyMaps(idType)
   const idDuplets = listings.map(listing => Object.fromEntries(keyMaps.map(keyMap => [keyMap.key, listing[keyMap.listingKey]])))

--- a/helpers/process-report.js
+++ b/helpers/process-report.js
@@ -15,7 +15,7 @@ function getIdsMap (parsedReport, idType) {
 
 function getIdKeysMaps (idType) {
   const IdKeysMaps = [{ key: 'ean', listingKey: 'product-id' }, { key: 'asin', listingKey: 'asin1' }, { key: 'sellerSku', listingKey: 'seller-sku' }]
-  const idIndex = IdKeysMaps.indexOf(IdKeysMaps.filter(idMap => idMap.key === idType))
+  const idIndex = IdKeysMaps.findIndex(IdKeysMap => IdKeysMap.key === idType)
   return IdKeysMaps.slice(idIndex, idIndex + 2)
 }
 

--- a/helpers/process-report.js
+++ b/helpers/process-report.js
@@ -14,8 +14,8 @@ module.exports = (parsedReport, marketplace) => {
       asinSkuMaps: asinSkuMaps.filter(asinSkuMap => !connectedAsins.includes(asinSkuMap.asin))
     }
   })
-  console.log(JSON.stringify(eanAsinMap, null, 2))
-  console.log(JSON.stringify(asinSkuMap, null, 2))
+  console.log(JSON.stringify(eanAsinMaps, null, 2))
+  console.log(JSON.stringify(asinSkuMaps, null, 2))
   console.log(JSON.stringify(connectedIdsMap, null, 2))
   console.log(JSON.stringify(orphanedIdsMap, null, 2))
 }

--- a/helpers/process-report.js
+++ b/helpers/process-report.js
@@ -1,33 +1,63 @@
 module.exports = (parsedReport, marketplace) => {
-  const eans = [...new Set(parsedReport.map(listing => listing['product-id']))]
-  return {
-    marketplace,
-    stockData: eans.map(getDataPerEan(parsedReport))
+  const eanAsinMap = getIdsMap(parsedReport, 'ean')
+  const asinSkuMap = getIdsMap(parsedReport, 'asin')
+  console.log(JSON.stringify(eanAsinMap, null, 2))
+  console.log(JSON.stringify(asinSkuMap, null, 2))
+}
+
+function getIdsMap (parsedReport, idType) {
+  const listings = idType === 'ean' ? parsedReport.filter(listing => listing['product-id-type'] === '4') : parsedReport
+  const idKeysMaps = getIdKeysMaps(idType)
+  const idDuplets = listings.map(listing => Object.fromEntries(idKeysMaps.map(idKeysMap => [idKeysMap.key, listing[idKeysMap.listingKey]])))
+  const ids = [...new Set(listings.map(listing => listing[idKeysMaps[0].listingKey]))]
+  return ids.map(buildIdsMap(idDuplets, idKeysMaps))
+}
+
+function getIdKeysMaps (idType) {
+  const IdKeysMaps = [{ key: 'ean', listingKey: 'product-id' }, { key: 'asin', listingKey: 'asin1' }, { key: 'sellerSku', listingKey: 'seller-sku' }]
+  const idIndex = IdKeysMaps.indexOf(IdKeysMaps.filter(idMap => idMap.key === idType))
+  return IdKeysMaps.slice(idIndex, idIndex + 2)
+}
+
+function buildIdsMap (idDuplets, idKeysMaps) {
+  return id => {
+    const matchingDuplets = idDuplets.filter(duplet => duplet[idKeysMaps[0].key] === id)
+    const idMapHandler = (idKeysMap, i) => i === 0 ? [idKeysMap.key, id] : [`${idKeysMap.key}s`, matchingDuplets.map(duplet => duplet[idKeysMaps[1].key])]
+    const idMap = idKeysMaps.map(idMapHandler)
+    return Object.fromEntries(idMap)
   }
 }
 
-function getDataPerEan(parsedReport) {
-  return ean => {
-    const matchingListings = parsedReport.filter(getMatchingListings(ean))
-    return {
-      ean,
-      stocks: matchingListings.map(getStocksForEntry)
-    }
-  }
-}
+// module.exports = (parsedReport, marketplace) => {
+//   const eans = [...new Set(parsedReport.map(listing => listing['product-id']))]
+//   return {
+//     marketplace,
+//     stockData: eans.map(getDataPerEan(parsedReport))
+//   }
+// }
 
-function getMatchingListings(ean) {
-  return listing => listing['product-id'] === ean
-}
+// function getDataPerEan(parsedReport) {
+//   return ean => {
+//     const matchingListings = parsedReport.filter(getMatchingListings(ean))
+//     return {
+//       ean,
+//       stocks: matchingListings.map(getStocksForEntry)
+//     }
+//   }
+// }
 
-function getStocksForEntry(listing) {
-  return {
-    asins: Object.entries(listing).filter(entry => entry[0].includes('asin')).map(entry => entry[1]).filter(asin => asin.length > 0),
-    sellerSku: listing['seller-sku'],
-    quantity: listing.quantity,
-    pendingQuantity: listing['pending-quantity'],
-    fulfilmentChannel: listing['fulfilment-channel'],
-    status: listing.status,
-    condition: listing['item-condition']
-  }
-}
+// function getMatchingListings(ean) {
+//   return listing => listing['product-id'] === ean
+// }
+
+// function getStocksForEntry(listing) {
+//   return {
+//     asins: Object.entries(listing).filter(entry => entry[0].includes('asin')).map(entry => entry[1]).filter(asin => asin.length > 0),
+//     sellerSku: listing['seller-sku'],
+//     quantity: listing.quantity,
+//     pendingQuantity: listing['pending-quantity'],
+//     fulfilmentChannel: listing['fulfilment-channel'],
+//     status: listing.status,
+//     condition: listing['item-condition']
+//   }
+// }


### PR DESCRIPTION
**Changes description**
Updated report processing logic to be able to extract accurate data from the parsed report.

**Updated features**
- _report processing:_ updated `process-report` helper of the lambda handler to correctly extract data from report.
This includes retrieving EAN-to-ASINs & ASIN-to-SellerSKUs mappings, fetching stock data for each SellerSKU and building the stock data for the target lambda that sets stocks in ES
It also logs any orphaned products (i.e. products for which there is an ASIN-to-SellerSKUs mapping but no EAN-to-ASINs mapping so we cannot map them to an internal product via EAN)